### PR TITLE
Add svelte-kit support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,10 @@ interface VisualObserverElement {
 
 const floor = Math.floor;
 
-const root = document.documentElement;
+let root: HTMLElement;
+if (typeof window != "undefined") {
+  root = document.documentElement;
+}
 
 /**
  * Create an observer that notifies when an element is resized, moved, or added/removed from the DOM.


### PR DESCRIPTION
This is a simple change that prevents this library erroring if used in a svelte-kit environment. This does mean `root` is potentially null but realistically the resize observer should not be used in a server side context.